### PR TITLE
Fix selection box rendering

### DIFF
--- a/src/imgui_plot.cpp
+++ b/src/imgui_plot.cpp
@@ -244,11 +244,11 @@ PlotStatus Plot(const char* label, const PlotConfig& conf) {
                     ClearActiveID();
                 }
             }
-
+            float fSelectionStep = 1.0 / item_count;
             ImVec2 pos0 = ImLerp(inner_bb.Min, inner_bb.Max,
-                                 ImVec2(t_step * *conf.selection.start, 0.f));
+                                 ImVec2(fSelectionStep * *conf.selection.start, 0.f));
             ImVec2 pos1 = ImLerp(inner_bb.Min, inner_bb.Max,
-                                ImVec2(t_step * (*conf.selection.start + *conf.selection.length), 1.f));
+                                ImVec2(fSelectionStep * (*conf.selection.start + *conf.selection.length), 1.f));
             window->DrawList->AddRectFilled(pos0, pos1, IM_COL32(128, 128, 128, 32));
             window->DrawList->AddRect(pos0, pos1, IM_COL32(128, 128, 128, 128));
         }


### PR DESCRIPTION
When `conf.skip_small_lines = true;` and the data length is greater than the window size, the t_step is no longer valid to draw the selection. Using the step calculated from the actual data length to fix the issue.